### PR TITLE
Add admin auth controller and polished views

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -30,6 +30,7 @@ class CreateNewUser implements CreatesNewUsers
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
+            'is_admin' => $input['is_admin'] ?? false,
         ]);
     }
 }

--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminAuthController extends Controller
+{
+    public function showLoginForm()
+    {
+        return view('auth.admin-login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        // Ensure the user is admin
+        $credentials['is_admin'] = true;
+
+        if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            $request->session()->regenerate();
+            return redirect()->intended('/dashboard');
+        }
+
+        return back()->withErrors([
+            'email' => __('auth.failed'),
+        ])->onlyInput('email');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,6 +29,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     /**
@@ -62,6 +63,12 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
+    }
+
+    public function isAdmin(): bool
+    {
+        return (bool) $this->is_admin;
     }
 }

--- a/resources/views/auth/admin-login.blade.php
+++ b/resources/views/auth/admin-login.blade.php
@@ -4,7 +4,7 @@
             <x-authentication-card-logo />
         </x-slot>
 
-        <h1 class="text-2xl font-bold mb-6 text-center">{{ __('Sign in to your account') }}</h1>
+        <h1 class="text-2xl font-bold mb-6 text-center">{{ __('Admin Login') }}</h1>
 
         <x-validation-errors class="mb-4" />
 
@@ -14,7 +14,7 @@
             </div>
         @endsession
 
-        <form method="POST" action="{{ route('login') }}">
+        <form method="POST" action="{{ route('admin.login.submit') }}">
             @csrf
 
             <div>
@@ -40,8 +40,6 @@
                         {{ __('Forgot your password?') }}
                     </a>
                 @endif
-
-                <a href="{{ route('admin.login') }}" class="text-xs text-gray-500 hover:text-gray-700 mr-auto">{{ __('Admin?') }}</a>
 
                 <x-button class="ms-4">
                     {{ __('Log in') }}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,6 +4,8 @@
             <x-authentication-card-logo />
         </x-slot>
 
+        <h1 class="text-2xl font-bold mb-6 text-center">{{ __('Create an account') }}</h1>
+
         <x-validation-errors class="mb-4" />
 
         <form method="POST" action="{{ route('register') }}">
@@ -46,10 +48,12 @@
                 </div>
             @endif
 
-            <div class="flex items-center justify-end mt-4">
+            <div class="flex items-center justify-between mt-4">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
                     {{ __('Already registered?') }}
                 </a>
+
+                <a href="{{ route('admin.login') }}" class="text-xs text-gray-500 hover:text-gray-700 mr-auto ml-2">{{ __('Admin?') }}</a>
 
                 <x-button class="ms-4">
                     {{ __('Register') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\PageController;
 use App\Http\Controllers\BlogController;
 use App\Http\Controllers\BusinessCategoryController;
 use App\Http\Controllers\TeamController;
+use App\Http\Controllers\AdminAuthController;
  
 
 // Landing Pages
@@ -26,6 +27,11 @@ Route::get('/blog/{slug}', [BlogController::class, 'show'])->name('blog.show');
 
 // Team
 Route::get('/team', [TeamController::class, 'index'])->name('team.index');
+
+
+// Admin Authentication
+Route::get('/admin/login', [AdminAuthController::class, 'showLoginForm'])->name('admin.login');
+Route::post('/admin/login', [AdminAuthController::class, 'login'])->name('admin.login.submit');
 
 
 Route::get('/api/product/{productId}', [PageController::class, 'getProductDetails']);


### PR DESCRIPTION
## Summary
- allow `is_admin` field in User model and casts
- update CreateNewUser action to set `is_admin`
- polish login and register pages with headings and admin links
- add admin login view and controller
- register admin login routes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c95f91b2c832489a1d009755e07cf