### PR TITLE
Add email sending for contact form

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Contact;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\ContactMessage;
 
 class ContactController extends Controller
 {
@@ -21,6 +23,13 @@ class ContactController extends Controller
             'message' => 'nullable',
         ]);
         Contact::create($data);
+        Mail::to('agumabanksibrahim@gmail.com')->send(
+            new ContactMessage(
+                $data['name'],
+                $data['email'],
+                $data['message'] ?? null
+            )
+        );
         return back()->with('status', 'Message sent');
     }
 }

--- a/app/Mail/ContactMessage.php
+++ b/app/Mail/ContactMessage.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ContactMessage extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public string $name;
+    public string $email;
+    public ?string $content;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(string $name, string $email, ?string $content)
+    {
+        $this->name = $name;
+        $this->email = $email;
+        $this->content = $content;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Contact Message',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.contact_message',
+            with: [
+                'name' => $this->name,
+                'email' => $this->email,
+                'content' => $this->content,
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/views/emails/contact_message.blade.php
+++ b/resources/views/emails/contact_message.blade.php
@@ -1,0 +1,5 @@
+<p>You have received a new contact message.</p>
+<p><strong>Name:</strong> {{ $name }}</p>
+<p><strong>Email:</strong> {{ $email }}</p>
+<p><strong>Message:</strong></p>
+<p>{{ $content }}</p>

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -15,6 +15,7 @@
                     <ul class="space-y-2 text-gray-700">
                         <li><span class="font-semibold">Customer Support:</span> 0706 27-2481</li>
                         <li><span class="font-semibold">Sales:</span> 0200 90-3222</li>
+                        <li><span class="font-semibold">WhatsApp:</span> <a href="https://wa.me/256706272481" class="text-green-600 underline">Chat with us</a></li>
                         <li><span class="font-semibold">Address:</span> Kampala, Uganda</li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Summary
- email submissions to agumabanksibrahim@gmail.com using a new `ContactMessage` mailable
- list a WhatsApp chat link in the contact page
- show the submitted name, email and message in the outgoing email

## Testing
- `php artisan test` *(fails: Database file at path [/workspace/sanaa-website/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684d12453a688324bb84dc4b7e4a273c