### PR TITLE
Add editable terms and seller policies

### DIFF
--- a/app/Http/Controllers/PolicyController.php
+++ b/app/Http/Controllers/PolicyController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Policy;
+use Illuminate\Http\Request;
+
+class PolicyController extends Controller
+{
+    public function show(string $key)
+    {
+        $policy = Policy::where('key', $key)->firstOrFail();
+        return view('pages.policy_show', compact('policy'));
+    }
+
+    public function update(Request $request, string $key)
+    {
+        $data = $request->validate([
+            'content' => 'required',
+        ]);
+
+        Policy::updateOrCreate(
+            ['key' => $key],
+            ['title' => ucwords(str_replace('-', ' ', $key)), 'content' => $data['content']]
+        );
+
+        return redirect()->route('dashboard')->with('status', 'Policy updated');
+    }
+}

--- a/app/Models/Policy.php
+++ b/app/Models/Policy.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Policy extends Model
+{
+    protected $fillable = ['key', 'title', 'content'];
+}

--- a/database/migrations/2025_06_10_000007_create_policies_table.php
+++ b/database/migrations/2025_06_10_000007_create_policies_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('policies', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('title');
+            $table->text('content')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('policies');
+    }
+};

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -230,7 +230,8 @@
       <ul class="flex flex-col space-y-1 text-sm text-right">
         <li><a href="#" class="hover:underline">Privacy Notice</a></li>
         <li><a href="#" class="hover:underline">Security</a></li>
-        <li><a href="#" class="hover:underline">Terms of Service</a></li>
+        <li><a href="{{ route('terms') }}" class="hover:underline">Terms &amp; Conditions</a></li>
+        <li><a href="{{ route('seller-policies') }}" class="hover:underline">Seller Policies</a></li>
         <li><a href="#" class="hover:underline">Government</a></li>
         <li><a href="#" class="hover:underline">Licenses</a></li>
         <li><a href="#" class="hover:underline">Sanaa Brands Licenses</a></li>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -137,7 +137,25 @@
                         <x-label for="price-description" value="Description" />
                         <textarea id="price-description" name="description" class="w-full rounded"></textarea>
                     </div>
-                    <x-button>Create</x-button>
+                <x-button>Create</x-button>
+                </form>
+
+                <h3 class="text-lg font-semibold mb-4 mt-8">Edit Terms &amp; Conditions</h3>
+                <form method="POST" action="{{ route('dashboard.policy.update', ['key' => 'terms']) }}">
+                    @csrf
+                    <div class="mb-4">
+                        <textarea id="terms-content" name="content" class="w-full rounded" rows="5">{{ $terms->content ?? '' }}</textarea>
+                    </div>
+                    <x-button>Save</x-button>
+                </form>
+
+                <h3 class="text-lg font-semibold mb-4 mt-8">Edit Seller Policies</h3>
+                <form method="POST" action="{{ route('dashboard.policy.update', ['key' => 'seller-policies']) }}">
+                    @csrf
+                    <div class="mb-4">
+                        <textarea id="seller-content" name="content" class="w-full rounded" rows="5">{{ $seller->content ?? '' }}</textarea>
+                    </div>
+                    <x-button>Save</x-button>
                 </form>
             </div>
         </div>

--- a/resources/views/pages/policy_show.blade.php
+++ b/resources/views/pages/policy_show.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.landing')
+
+@section('content')
+<section class="py-12 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 class="text-2xl font-bold">{{ $policy->title }}</h1>
+        <div class="mt-4 prose">
+            {!! $policy->content !!}
+        </div>
+    </div>
+</section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,8 @@ use App\Http\Controllers\HardwareRentalController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\PriceController;
 use App\Http\Controllers\AdminAuthController;
+use App\Http\Controllers\PolicyController;
+use App\Models\Policy;
  
 
 // Landing Pages
@@ -29,6 +31,8 @@ Route::get('/bulk-sms', [PageController::class, 'bulkSms'])->name('bulk-sms');
 Route::get('/prices', [PageController::class, 'prices'])->name('prices');
 Route::get('/careers', [CareerController::class, 'index'])->name('careers');
 Route::get('/partners', [PartnerController::class, 'index'])->name('partners');
+Route::get('/terms', [PolicyController::class, 'show'])->defaults('key', 'terms')->name('terms');
+Route::get('/seller-policies', [PolicyController::class, 'show'])->defaults('key', 'seller-policies')->name('seller-policies');
 Route::get('/developer-platforms', [DeveloperPlatformController::class, 'index'])->name('developer-platforms');
 Route::get('/rent-hardware', [HardwareRentalController::class, 'index'])->name('rent-hardware');
 Route::get('/contact', [ContactController::class, 'index'])->name('contact');
@@ -59,7 +63,9 @@ Route::middleware([
     'verified',
 ])->group(function () {
     Route::get('/dashboard', function () {
-        return view('dashboard');
+        $terms = Policy::where('key', 'terms')->first();
+        $seller = Policy::where('key', 'seller-policies')->first();
+        return view('dashboard', compact('terms', 'seller'));
     })->name('dashboard');
 
     Route::post('/dashboard/blog', [BlogController::class, 'store'])->name('dashboard.blog.store');
@@ -70,4 +76,5 @@ Route::middleware([
     Route::post('/dashboard/developer-platform', [DeveloperPlatformController::class, 'store'])->name('dashboard.developer-platform.store');
     Route::post('/dashboard/hardware-rental', [HardwareRentalController::class, 'store'])->name('dashboard.hardware-rental.store');
     Route::post('/dashboard/price', [PriceController::class, 'store'])->name('dashboard.price.store');
+    Route::post('/dashboard/policy/{key}', [PolicyController::class, 'update'])->name('dashboard.policy.update');
 });


### PR DESCRIPTION
## Summary
- create Policy model and migration
- add PolicyController with show/update
- expose `/terms` and `/seller-policies` routes
- load policy data on the dashboard
- allow editing policies via dashboard forms
- link new pages from footer

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bbfff25c8324987d9ef311f57d71