### PR TITLE
Add team CRUD and dynamic landing section

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -15,9 +15,11 @@ class PageController extends Controller
     public function home()
     {
         $sokoProducts = Http::get('https://soko.sanaa.co/api/v2/products')->json();
-        // return view('your-view', );
-        // dd($sokoProducts);
-        return view('pages.home',['sokoProducts' => $sokoProducts]);
+        $teamMembers = \App\Models\TeamMember::all();
+        return view('pages.home', [
+            'sokoProducts' => $sokoProducts,
+            'teamMembers' => $teamMembers,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\TeamMember;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Request;
 
 class TeamController extends Controller
@@ -29,5 +30,32 @@ class TeamController extends Controller
         TeamMember::create($data);
 
         return redirect()->route('dashboard')->with('status', 'Team member created');
+    }
+
+    public function update(Request $request, TeamMember $member)
+    {
+        $data = $request->validate([
+            'name' => 'required',
+            'title' => 'nullable',
+            'bio' => 'nullable',
+            'photo' => 'nullable|image',
+        ]);
+
+        if ($request->hasFile('photo')) {
+            $data['photo'] = $request->file('photo')->store('team', 'public');
+        }
+
+        $member->update($data);
+
+        return redirect()->route('dashboard')->with('status', 'Team member updated');
+    }
+
+    public function destroy(TeamMember $member)
+    {
+        if ($member->photo) {
+            Storage::disk('public')->delete($member->photo);
+        }
+        $member->delete();
+        return redirect()->route('dashboard')->with('status', 'Team member deleted');
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Database\Seeders\BlogSeeder;
+use Database\Seeders\TeamMemberSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -21,6 +22,9 @@ class DatabaseSeeder extends Seeder
             'email' => 'test@example.com',
         ]);
 
-        $this->call(BlogSeeder::class);
+        $this->call([
+            BlogSeeder::class,
+            TeamMemberSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/TeamMemberSeeder.php
+++ b/database/seeders/TeamMemberSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\TeamMember;
+
+class TeamMemberSeeder extends Seeder
+{
+    public function run(): void
+    {
+        TeamMember::truncate();
+
+        TeamMember::create([
+            'name' => 'Aguma I. Banks',
+            'title' => 'Founder & CEO',
+            'bio' => 'Visionary leader building digital infrastructure across Africa.',
+            'photo' => null,
+        ]);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -66,6 +66,49 @@
                 <x-button>Add Member</x-button>
                 </form>
 
+                @if(isset($teamMembers) && $teamMembers->count())
+                <h3 class="text-lg font-semibold mb-4 mt-8">Manage Team Members</h3>
+                <div class="space-y-6">
+                    @foreach($teamMembers as $member)
+                        <div class="border p-4 rounded">
+                            <form method="POST" action="{{ route('dashboard.team.update', $member) }}" enctype="multipart/form-data" class="space-y-4">
+                                @csrf
+                                @method('PUT')
+                                <div class="flex items-center space-x-4">
+                                    @if($member->photo)
+                                        <img src="{{ asset('storage/'.$member->photo) }}" class="w-16 h-16 rounded-full object-cover" alt="{{ $member->name }}">
+                                    @endif
+                                    <div class="flex-1">
+                                        <x-label for="name-{{ $member->id }}" value="Name" />
+                                        <x-input id="name-{{ $member->id }}" name="name" class="w-full" value="{{ $member->name }}" />
+                                    </div>
+                                    <div class="flex-1">
+                                        <x-label for="title-{{ $member->id }}" value="Title" />
+                                        <x-input id="title-{{ $member->id }}" name="title" class="w-full" value="{{ $member->title }}" />
+                                    </div>
+                                </div>
+                                <div>
+                                    <x-label for="bio-{{ $member->id }}" value="Bio" />
+                                    <textarea id="bio-{{ $member->id }}" name="bio" class="w-full rounded">{{ $member->bio }}</textarea>
+                                </div>
+                                <div>
+                                    <x-label for="photo-{{ $member->id }}" value="Photo" />
+                                    <input type="file" name="photo" id="photo-{{ $member->id }}">
+                                </div>
+                                <div class="flex space-x-2">
+                                    <x-button>Update</x-button>
+                                </div>
+                            </form>
+                            <form method="POST" action="{{ route('dashboard.team.destroy', $member) }}" class="mt-2">
+                                @csrf
+                                @method('DELETE')
+                                <x-button class="bg-red-500 hover:bg-red-600">Delete</x-button>
+                            </form>
+                        </div>
+                    @endforeach
+                </div>
+                @endif
+
                 <h3 class="text-lg font-semibold mb-4 mt-8">Add Career</h3>
                 <form method="POST" action="{{ route('dashboard.career.store') }}">
                     @csrf

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -110,12 +110,17 @@
       <div class="container mx-auto px-4">
         <h2 class="text-3xl font-bold mb-8 text-center">Meet the Team</h2>
         <div class="grid md:grid-cols-3 gap-8">
+          @foreach($teamMembers as $member)
           <div class="text-center">
-            <img src="/img/placeholder-team.jpg" alt="Aguma I. Banks" class="w-32 h-32 rounded-full mx-auto mb-4">
-            <h3 class="text-xl font-semibold">Aguma I. Banks</h3>
-            <p class="text-gray-600">Founder &amp; CEO</p>
+            @if($member->photo)
+            <img src="{{ asset('storage/'.$member->photo) }}" alt="{{ $member->name }}" class="w-32 h-32 rounded-full mx-auto mb-4">
+            @endif
+            <h3 class="text-xl font-semibold">{{ $member->name }}</h3>
+            @if($member->title)
+            <p class="text-gray-600">{{ $member->title }}</p>
+            @endif
           </div>
-          <!-- Additional team members can be added here -->
+          @endforeach
         </div>
       </div>
     </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,12 +65,15 @@ Route::middleware([
     Route::get('/dashboard', function () {
         $terms = Policy::where('key', 'terms')->first();
         $seller = Policy::where('key', 'seller-policies')->first();
-        return view('dashboard', compact('terms', 'seller'));
+        $teamMembers = \App\Models\TeamMember::all();
+        return view('dashboard', compact('terms', 'seller', 'teamMembers'));
     })->name('dashboard');
 
     Route::post('/dashboard/blog', [BlogController::class, 'store'])->name('dashboard.blog.store');
     Route::post('/dashboard/category', [\App\Http\Controllers\BusinessCategoryController::class, 'store'])->name('dashboard.category.store');
     Route::post('/dashboard/team', [TeamController::class, 'store'])->name('dashboard.team.store');
+    Route::put('/dashboard/team/{member}', [TeamController::class, 'update'])->name('dashboard.team.update');
+    Route::delete('/dashboard/team/{member}', [TeamController::class, 'destroy'])->name('dashboard.team.destroy');
     Route::post('/dashboard/career', [CareerController::class, 'store'])->name('dashboard.career.store');
     Route::post('/dashboard/partner', [PartnerController::class, 'store'])->name('dashboard.partner.store');
     Route::post('/dashboard/developer-platform', [DeveloperPlatformController::class, 'store'])->name('dashboard.developer-platform.store');


### PR DESCRIPTION
## Summary
- enable team CRUD in `TeamController`
- seed default team member
- expose team members to dashboard and homepage
- add management UI for members in the dashboard
- display dynamic team data on the landing page

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c3232d708324874f45b0ae33f025