### PR TITLE
Add dedicated team member edit page

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -14,6 +14,11 @@ class TeamController extends Controller
         return view('team.index', compact('members'));
     }
 
+    public function edit(TeamMember $member)
+    {
+        return view('dashboard.team-edit', compact('member'));
+    }
+
     public function store(Request $request)
     {
         $data = $request->validate([

--- a/resources/views/dashboard/team-edit.blade.php
+++ b/resources/views/dashboard/team-edit.blade.php
@@ -1,0 +1,46 @@
+<x-dashboard-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Edit Team Member
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('dashboard.team.update', $member) }}" enctype="multipart/form-data" class="space-y-4">
+                    @csrf
+                    @method('PUT')
+                    <div>
+                        <x-label for="name" value="Name" />
+                        <x-input id="name" name="name" class="w-full" value="{{ $member->name }}" />
+                    </div>
+                    <div>
+                        <x-label for="title" value="Title" />
+                        <x-input id="title" name="title" class="w-full" value="{{ $member->title }}" />
+                    </div>
+                    <div>
+                        <x-label for="bio" value="Bio" />
+                        <textarea id="bio" name="bio" class="w-full rounded">{{ $member->bio }}</textarea>
+                    </div>
+                    <div>
+                        <x-label for="photo" value="Photo" />
+                        <input type="file" name="photo" id="photo">
+                        @if($member->photo)
+                            <img src="{{ asset('storage/'.$member->photo) }}" class="w-24 h-24 mt-2 rounded-full object-cover" alt="{{ $member->name }}">
+                        @endif
+                    </div>
+                    <div class="flex space-x-2">
+                        <x-button>Save</x-button>
+                        <a href="{{ route('dashboard.team') }}" class="inline-flex items-center px-4 py-2 bg-gray-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-600 focus:outline-none focus:border-gray-600 focus:ring focus:ring-gray-200 active:bg-gray-600 disabled:opacity-25 transition">Cancel</a>
+                    </div>
+                </form>
+                <form method="POST" action="{{ route('dashboard.team.destroy', $member) }}" class="mt-4">
+                    @csrf
+                    @method('DELETE')
+                    <x-button class="bg-red-500 hover:bg-red-600">Delete</x-button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-dashboard-layout>

--- a/resources/views/dashboard/team.blade.php
+++ b/resources/views/dashboard/team.blade.php
@@ -61,6 +61,7 @@
                                 </div>
                                 <div class="flex space-x-2">
                                     <x-button>Update</x-button>
+                                    <a href="{{ route('dashboard.team.edit', $member) }}" class="inline-flex items-center px-4 py-2 bg-gray-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-600 focus:outline-none focus:border-gray-600 focus:ring focus:ring-gray-200 active:bg-gray-600 disabled:opacity-25 transition">More</a>
                                 </div>
                             </form>
                             <form method="POST" action="{{ route('dashboard.team.destroy', $member) }}" class="mt-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,7 @@ Route::middleware([
         $teamMembers = \App\Models\TeamMember::all();
         return view('dashboard.team', compact('teamMembers'));
     })->name('dashboard.team');
+    Route::get('/dashboard/team/{member}', [TeamController::class, 'edit'])->name('dashboard.team.edit');
 
     Route::get('/dashboard/careers', function () {
         return view('dashboard.careers');


### PR DESCRIPTION
## Summary
- add GET route for editing a single team member
- handle new `edit` method in `TeamController`
- add `team-edit` dashboard view for editing and deleting a member
- link to the new edit page from team list

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*
- `composer update --no-interaction` *(fails: missing PHP xml extension)*

------
https://chatgpt.com/codex/tasks/task_e_6854cdc562148324b26200ec086ab15c