### PR TITLE
Add custom titles across pages

### DIFF
--- a/resources/views/api/index.blade.php
+++ b/resources/views/api/index.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'API Tokens | ' . config('app.name'))
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">

--- a/resources/views/auth/admin-login.blade.php
+++ b/resources/views/auth/admin-login.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Admin Login | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Confirm Password | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Forgot Password | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Login | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Register | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Reset Password | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Two Factor Challenge | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Verify Email | ' . config('app.name'))
 <x-guest-layout>
     <x-authentication-card>
         <x-slot name="logo">

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Blog | ' . config('app.name'))
+
 @section('content')
 <div class="container mx-auto py-12 px-4">
     <h1 class="text-3xl font-bold mb-8">Blog</h1>

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', $post->title . ' | ' . config('app.name'))
+
 @section('content')
 <div class="container mx-auto py-12 px-4 max-w-4xl">
     <article class="prose lg:prose-lg">

--- a/resources/views/dashboard/blog.blade.php
+++ b/resources/views/dashboard/blog.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Blog">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Blog

--- a/resources/views/dashboard/careers.blade.php
+++ b/resources/views/dashboard/careers.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Careers">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Careers

--- a/resources/views/dashboard/categories.blade.php
+++ b/resources/views/dashboard/categories.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Categories">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Categories

--- a/resources/views/dashboard/developer-platforms.blade.php
+++ b/resources/views/dashboard/developer-platforms.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Developer Platforms">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Developer Platforms

--- a/resources/views/dashboard/hardware-rentals.blade.php
+++ b/resources/views/dashboard/hardware-rentals.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Hardware Rentals">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Hardware Rentals

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Dashboard">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Dashboard') }}

--- a/resources/views/dashboard/partners.blade.php
+++ b/resources/views/dashboard/partners.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Partners">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Partners

--- a/resources/views/dashboard/policies.blade.php
+++ b/resources/views/dashboard/policies.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Policies">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Policies

--- a/resources/views/dashboard/prices.blade.php
+++ b/resources/views/dashboard/prices.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Prices">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Prices

--- a/resources/views/dashboard/team-edit.blade.php
+++ b/resources/views/dashboard/team-edit.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Edit Team Member">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Edit Team Member

--- a/resources/views/dashboard/team.blade.php
+++ b/resources/views/dashboard/team.blade.php
@@ -1,4 +1,4 @@
-<x-dashboard-layout>
+<x-dashboard-layout title="Team">
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             Team

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Sanaa Co.') }}</title>
+        <title>@yield('title', config('app.name', 'Sanaa Co.'))</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Sanaa Co.') }}</title>
+        <title>{{ $title ?? config('app.name', 'Sanaa Co.') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        <title>@yield('title', config('app.name', 'Sanaa Co.'))</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -42,7 +42,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        <title>@yield('title', config('app.name', 'Sanaa Co.'))</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/landing.blade.php
+++ b/resources/views/layouts/landing.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Sanaa Co.</title>
+        <title>@yield('title', 'Sanaa Co.')</title>
 
         
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/resources/views/pages/about.blade.php
+++ b/resources/views/pages/about.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'About Us | ' . config('app.name'))
+
 @section('content')
 <section class="py-12 bg-white">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">

--- a/resources/views/pages/bulk-sms.blade.php
+++ b/resources/views/pages/bulk-sms.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Bulk SMS | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/careers.blade.php
+++ b/resources/views/pages/careers.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Careers | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/company.blade.php
+++ b/resources/views/pages/company.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Company | ' . config('app.name'))
+
 @section('content')
 
 <div class="container mx-auto py-12 px-4">

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Contact Us | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">

--- a/resources/views/pages/developer-platforms.blade.php
+++ b/resources/views/pages/developer-platforms.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Developer Platforms | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Home | ' . config('app.name'))
+
 @section('content')
   <div class="body">
     <div role="main" class="main">

--- a/resources/views/pages/partners.blade.php
+++ b/resources/views/pages/partners.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Partners | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/policy.blade.php
+++ b/resources/views/pages/policy.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Policies | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/policy_show.blade.php
+++ b/resources/views/pages/policy_show.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', $policy->title . ' | ' . config('app.name'))
+
 @section('content')
 <section class="py-12 bg-white">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/prices.blade.php
+++ b/resources/views/pages/prices.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Prices | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/products.blade.php
+++ b/resources/views/pages/products.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Products | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/rent-hardware.blade.php
+++ b/resources/views/pages/rent-hardware.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Hardware Rentals | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/services.blade.php
+++ b/resources/views/pages/services.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Services | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/pages/support.blade.php
+++ b/resources/views/pages/support.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.landing')
 
+@section('title', 'Support | ' . config('app.name'))
+
 @section('content')
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/policy.blade.php
+++ b/resources/views/policy.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Privacy Policy | ' . config('app.name'))
 <x-guest-layout>
     <div class="pt-4 bg-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Profile | ' . config('app.name'))
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,3 +1,4 @@
+@section('title', 'Terms and Conditions | ' . config('app.name'))
 <x-guest-layout>
     <div class="pt-4 bg-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Laravel</title>
+        <title>@yield('title', config('app.name', 'Sanaa Co.'))</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## Summary
- allow layouts to accept a title section
- set page-specific titles for site pages, dashboard screens and auth views

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d0c6bf188324a771171a8eb4c4f2