### PR TITLE
Improve support form

### DIFF
--- a/app/Http/Controllers/SupportController.php
+++ b/app/Http/Controllers/SupportController.php
@@ -4,20 +4,46 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\SupportRequestMessage;
+use App\Models\SupportRequest;
 
 class SupportController extends Controller
 {
     public function send(Request $request)
     {
         $data = $request->validate([
+            'name' => 'required|string',
+            'phone' => 'nullable|string',
+            'email' => 'nullable|email',
+            'address' => 'nullable|string',
+            'product' => 'nullable|string',
             'message' => 'required|string',
         ]);
+
+        $support = SupportRequest::create($data);
+
+        Mail::to('info@sanaa.co')->send(new SupportRequestMessage(
+            $support->name,
+            $support->email,
+            $support->phone,
+            $support->address,
+            $support->product,
+            $support->message,
+        ));
+
+        $text = sprintf(
+            'Support request from %s%s: %s',
+            $support->name,
+            $support->product ? " about {$support->product}" : '',
+            $support->message
+        );
 
         $response = Http::get('https://custom.trustsmsuganda.com/text_api/', [
             'api_key' => 'ZCH6QK',
             'sender' => '',
             'contacts' => '256706272481',
-            'text' => $data['message'],
+            'text' => $text,
         ]);
 
         if ($response->successful()) {

--- a/app/Mail/SupportRequestMessage.php
+++ b/app/Mail/SupportRequestMessage.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class SupportRequestMessage extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public string $name;
+    public ?string $email;
+    public ?string $phone;
+    public ?string $address;
+    public ?string $product;
+    public string $content;
+
+    public function __construct(
+        string $name,
+        ?string $email,
+        ?string $phone,
+        ?string $address,
+        ?string $product,
+        string $content,
+    ) {
+        $this->name = $name;
+        $this->email = $email;
+        $this->phone = $phone;
+        $this->address = $address;
+        $this->product = $product;
+        $this->content = $content;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Support Request',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.support_request',
+            with: [
+                'name' => $this->name,
+                'email' => $this->email,
+                'phone' => $this->phone,
+                'address' => $this->address,
+                'product' => $this->product,
+                'content' => $this->content,
+            ],
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/SupportRequest.php
+++ b/app/Models/SupportRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SupportRequest extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'address',
+        'product',
+        'message',
+    ];
+}

--- a/database/migrations/2025_06_10_000008_create_support_requests_table.php
+++ b/database/migrations/2025_06_10_000008_create_support_requests_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('support_requests', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+            $table->string('product')->nullable();
+            $table->text('message');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('support_requests');
+    }
+};

--- a/resources/views/emails/support_request.blade.php
+++ b/resources/views/emails/support_request.blade.php
@@ -1,0 +1,16 @@
+<p>You have received a new support request.</p>
+<p><strong>Name:</strong> {{ $name }}</p>
+@if($email)
+<p><strong>Email:</strong> {{ $email }}</p>
+@endif
+@if($phone)
+<p><strong>Phone:</strong> {{ $phone }}</p>
+@endif
+@if($address)
+<p><strong>Address:</strong> {{ $address }}</p>
+@endif
+@if($product)
+<p><strong>Product:</strong> {{ $product }}</p>
+@endif
+<p><strong>Message:</strong></p>
+<p>{{ $content }}</p>

--- a/resources/views/pages/support.blade.php
+++ b/resources/views/pages/support.blade.php
@@ -17,11 +17,31 @@
             <form action="{{ route('support.send') }}" method="POST" class="space-y-4">
                 @csrf
                 <div>
+                    <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                    <input id="name" name="name" type="text" required class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                </div>
+                <div>
+                    <label for="phone" class="block text-sm font-medium text-gray-700">Phone</label>
+                    <input id="phone" name="phone" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                </div>
+                <div>
+                    <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                    <input id="email" name="email" type="email" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                </div>
+                <div>
+                    <label for="address" class="block text-sm font-medium text-gray-700">Address</label>
+                    <input id="address" name="address" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                </div>
+                <div>
+                    <label for="product" class="block text-sm font-medium text-gray-700">Product</label>
+                    <input id="product" name="product" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+                </div>
+                <div>
                     <label for="message" class="block text-sm font-medium text-gray-700">Message</label>
                     <textarea id="message" name="message" rows="4" required class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"></textarea>
                 </div>
                 <div>
-                    <button type="submit" class="inline-flex items-center px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700">Send SMS</button>
+                    <button type="submit" class="inline-flex items-center px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700">Send</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- expand SupportController to store details and send an email
- add model and migration for `support_requests`
- create mail class and email template for support requests
- update the support form view with fields for name, phone, email, address and product

## Testing
- `composer test` *(fails: `vendor/bin/pest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0285fa8083249d78e5b6b96cbc25