### PR TITLE
Add offerings management and blog CRUD

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -6,6 +6,7 @@ use App\Models\Blog;
 use Illuminate\Http\Request;
  
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
  
 
 class BlogController extends Controller
@@ -31,7 +32,7 @@ class BlogController extends Controller
             'image' => 'nullable|image',
         ]);
 
-        $data['slug'] = \Illuminate\Support\Str::slug($data['title']);
+        $data['slug'] = Str::slug($data['title']);
 
         if ($request->hasFile('image')) {
             $data['image'] = $request->file('image')->store('blog', 'public');
@@ -40,5 +41,37 @@ class BlogController extends Controller
         Blog::create($data);
 
         return redirect()->route('dashboard.blog')->with('status', 'Blog post created');
-    } 
+    }
+
+    public function update(Request $request, Blog $blog)
+    {
+        $data = $request->validate([
+            'title' => 'required',
+            'excerpt' => 'nullable',
+            'body' => 'required',
+            'image' => 'nullable|image',
+        ]);
+
+        $data['slug'] = Str::slug($data['title']);
+
+        if ($request->hasFile('image')) {
+            if ($blog->image) {
+                Storage::disk('public')->delete($blog->image);
+            }
+            $data['image'] = $request->file('image')->store('blog', 'public');
+        }
+
+        $blog->update($data);
+
+        return redirect()->route('dashboard.blog')->with('status', 'Blog post updated');
+    }
+
+    public function destroy(Blog $blog)
+    {
+        if ($blog->image) {
+            Storage::disk('public')->delete($blog->image);
+        }
+        $blog->delete();
+        return redirect()->route('dashboard.blog')->with('status', 'Blog post deleted');
+    }
 }

--- a/app/Http/Controllers/OfferingController.php
+++ b/app/Http/Controllers/OfferingController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Offering;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class OfferingController extends Controller
+{
+    public function index(string $type)
+    {
+        $items = Offering::where('type', $type)->get();
+        $view = $type === 'service' ? 'pages.services' : 'pages.products';
+        return view($view, compact('items'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required',
+            'type' => 'required',
+            'description' => 'nullable',
+            'link' => 'nullable|url',
+            'image' => 'nullable|image',
+        ]);
+
+        if ($request->hasFile('image')) {
+            $data['image'] = $request->file('image')->store('offerings', 'public');
+        }
+
+        Offering::create($data);
+
+        return redirect()->route('dashboard.offerings')->with('status', 'Offering created');
+    }
+
+    public function update(Request $request, Offering $offering)
+    {
+        $data = $request->validate([
+            'title' => 'required',
+            'type' => 'required',
+            'description' => 'nullable',
+            'link' => 'nullable|url',
+            'image' => 'nullable|image',
+        ]);
+
+        if ($request->hasFile('image')) {
+            if ($offering->image) {
+                Storage::disk('public')->delete($offering->image);
+            }
+            $data['image'] = $request->file('image')->store('offerings', 'public');
+        }
+
+        $offering->update($data);
+
+        return redirect()->route('dashboard.offerings')->with('status', 'Offering updated');
+    }
+
+    public function destroy(Offering $offering)
+    {
+        if ($offering->image) {
+            Storage::disk('public')->delete($offering->image);
+        }
+        $offering->delete();
+        return redirect()->route('dashboard.offerings')->with('status', 'Offering deleted');
+    }
+}

--- a/app/Models/Offering.php
+++ b/app/Models/Offering.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Offering extends Model
+{
+    protected $fillable = [
+        'title',
+        'type',
+        'description',
+        'link',
+        'image',
+    ];
+}

--- a/database/migrations/2025_06_11_000009_create_offerings_table.php
+++ b/database/migrations/2025_06_11_000009_create_offerings_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('offerings', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('type')->default('product');
+            $table->text('description')->nullable();
+            $table->string('link')->nullable();
+            $table->string('image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('offerings');
+    }
+};

--- a/resources/views/dashboard/blog.blade.php
+++ b/resources/views/dashboard/blog.blade.php
@@ -29,6 +29,43 @@
                     </div>
                     <x-button>Create</x-button>
                 </form>
+
+                @php($posts = \App\Models\Blog::orderByDesc('created_at')->get())
+                @if($posts->count())
+                    <h3 class="text-lg font-semibold mb-4">Manage Posts</h3>
+                    <div class="space-y-6">
+                        @foreach($posts as $post)
+                            <div class="border p-4 rounded">
+                                <form method="POST" action="{{ route('dashboard.blog.update', $post) }}" enctype="multipart/form-data" class="space-y-4">
+                                    @csrf
+                                    @method('PUT')
+                                    <div class="mb-4">
+                                        <x-label for="title-{{ $post->id }}" value="Title" />
+                                        <x-input id="title-{{ $post->id }}" name="title" class="w-full" value="{{ $post->title }}" />
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="excerpt-{{ $post->id }}" value="Excerpt" />
+                                        <textarea id="excerpt-{{ $post->id }}" name="excerpt" class="w-full rounded">{{ $post->excerpt }}</textarea>
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="body-{{ $post->id }}" value="Body" />
+                                        <textarea id="body-{{ $post->id }}" name="body" class="w-full rounded" rows="5">{{ $post->body }}</textarea>
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="image-{{ $post->id }}" value="Image" />
+                                        <input type="file" name="image" id="image-{{ $post->id }}">
+                                    </div>
+                                    <x-button>Update</x-button>
+                                </form>
+                                <form method="POST" action="{{ route('dashboard.blog.destroy', $post) }}" class="mt-2">
+                                    @csrf
+                                    @method('DELETE')
+                                    <x-button class="bg-red-500 hover:bg-red-600">Delete</x-button>
+                                </form>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/dashboard/offerings.blade.php
+++ b/resources/views/dashboard/offerings.blade.php
@@ -1,0 +1,85 @@
+<x-dashboard-layout title="Offerings">
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            Products & Services
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg p-6">
+                <h3 class="text-lg font-semibold mb-4">Add Offering</h3>
+                <form method="POST" action="{{ route('dashboard.offering.store') }}" enctype="multipart/form-data">
+                    @csrf
+                    <div class="mb-4">
+                        <x-label for="offering-title" value="Title" />
+                        <x-input id="offering-title" name="title" class="w-full" />
+                    </div>
+                    <div class="mb-4">
+                        <x-label for="offering-type" value="Type" />
+                        <select id="offering-type" name="type" class="w-full rounded">
+                            <option value="product">Product</option>
+                            <option value="service">Service</option>
+                        </select>
+                    </div>
+                    <div class="mb-4">
+                        <x-label for="offering-description" value="Description" />
+                        <textarea id="offering-description" name="description" class="w-full rounded"></textarea>
+                    </div>
+                    <div class="mb-4">
+                        <x-label for="offering-link" value="Link" />
+                        <x-input id="offering-link" name="link" class="w-full" />
+                    </div>
+                    <div class="mb-4">
+                        <x-label for="offering-image" value="Image" />
+                        <input type="file" name="image" id="offering-image">
+                    </div>
+                    <x-button>Create</x-button>
+                </form>
+
+                @if(isset($items) && $items->count())
+                    <h3 class="text-lg font-semibold mb-4 mt-8">Manage Offerings</h3>
+                    <div class="space-y-6">
+                        @foreach($items as $offering)
+                            <div class="border p-4 rounded">
+                                <form method="POST" action="{{ route('dashboard.offering.update', $offering) }}" enctype="multipart/form-data" class="space-y-4">
+                                    @csrf
+                                    @method('PUT')
+                                    <div class="mb-4">
+                                        <x-label for="title-{{ $offering->id }}" value="Title" />
+                                        <x-input id="title-{{ $offering->id }}" name="title" class="w-full" value="{{ $offering->title }}" />
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="type-{{ $offering->id }}" value="Type" />
+                                        <select id="type-{{ $offering->id }}" name="type" class="w-full rounded">
+                                            <option value="product" @if($offering->type=='product') selected @endif>Product</option>
+                                            <option value="service" @if($offering->type=='service') selected @endif>Service</option>
+                                        </select>
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="description-{{ $offering->id }}" value="Description" />
+                                        <textarea id="description-{{ $offering->id }}" name="description" class="w-full rounded">{{ $offering->description }}</textarea>
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="link-{{ $offering->id }}" value="Link" />
+                                        <x-input id="link-{{ $offering->id }}" name="link" class="w-full" value="{{ $offering->link }}" />
+                                    </div>
+                                    <div class="mb-4">
+                                        <x-label for="image-{{ $offering->id }}" value="Image" />
+                                        <input type="file" name="image" id="image-{{ $offering->id }}">
+                                    </div>
+                                    <x-button>Update</x-button>
+                                </form>
+                                <form method="POST" action="{{ route('dashboard.offering.destroy', $offering) }}" class="mt-2">
+                                    @csrf
+                                    @method('DELETE')
+                                    <x-button class="bg-red-500 hover:bg-red-600">Delete</x-button>
+                                </form>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</x-dashboard-layout>

--- a/resources/views/layouts/dashboard.blade.php
+++ b/resources/views/layouts/dashboard.blade.php
@@ -35,6 +35,7 @@
                     <a href="{{ route('dashboard.team') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Team</a>
                     <a href="{{ route('dashboard.careers') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Careers</a>
                     <a href="{{ route('dashboard.partners') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Partners</a>
+                    <a href="{{ route('dashboard.offerings') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Offerings</a>
                     <a href="{{ route('dashboard.developer-platforms') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Developers</a>
                     <a href="{{ route('dashboard.hardware-rentals') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Hardware Rentals</a>
                     <a href="{{ route('dashboard.prices') }}" class="block px-3 py-2 rounded hover:bg-gray-700">Prices</a>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -21,111 +21,31 @@
         </div>
       </section>
 
-    <!-- Sanaa OS/ERP Section (responsive improvements for small screens) -->
+    <!-- Products & Services Section -->
 <section id="services" class="section section-height-3 bg-primary border-0 m-0 appear-animation" data-appear-animation="fadeIn">
   <div class="container my-3">
-    <!-- Heading -->
     <div class="row mb-5">
       <div class="col text-center appear-animation" data-appear-animation="fadeInUpShorter" data-appear-animation-delay="200">
-        <h2 class="text-2xl font-weight-bold text-color-black mb-2">Sanaa OS/ERP</h2>
+        <h2 class="text-2xl font-weight-bold text-color-black mb-2">Sanaa Products & Services</h2>
       </div>
     </div>
-
-    <!-- First row -->
-    <div class="row mb-lg-4 gy-4"> <!-- gy-4 adds vertical gap on <lg screens -->
-
-      <!-- SOKO 24 -->
-      <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInLeftShorter" data-appear-animation-delay="300">
-        <div class="feature-box feature-box-style-2 h-100">
-          <div class="feature-box-icon"></div>
-          <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">SOKO 24</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              Our online shopping destination features authentic brands, everyday essentials, beauty/personal care items, and cutting‑edge gadgets. Our e‑commerce platform strives to redefine the shopping experience by focusing on value addition and supply chain innovation.
-            </p>
-            <!-- FULL‑WIDTH ON XS, AUTO ON SM+ -->
-            <a href="https://soko.sanaa.co" target="_blank" class="block w-full text-center sm:inline-block sm:w-auto mt-3 px-4 py-2 bg-white text-black rounded shadow hover:bg-gray-100 transition">
-              Visit Soko 24
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <!-- Sanaa Fi. -->
-      <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInUpShorter">
-        <div class="feature-box feature-box-style-2 h-100">
-          <div class="feature-box-icon"></div>
-          <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">SANAA Fi.</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              Provide the simplest and most reliable financial solution for businesses across Africa. From receiving payments to accessing credit, Sanaa Fi aims to simplify the way businesses manage their finances in Africa.
-            </p>
-            <a href="https://fin.sanaa.co" target="_blank" class="block w-full text-center sm:inline-block sm:w-auto mt-3 px-4 py-2 bg-white text-black rounded shadow hover:bg-gray-100 transition">
-              Visit Sanaa Fin
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <!-- SANAA MEDIA -->
-      <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInRightShorter" data-appear-animation-delay="300">
-        <div class="feature-box feature-box-style-2 h-100">
-          <div class="feature-box-icon"></div>
-          <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">SANAA MEDIA</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              Serving African content creators by enabling them to build fully digital media brands ready to bridge the gap between the world's youngest continent, still primarily served by traditional media.
-            </p>
-            <a href="https://media.sanaa.co" target="_blank" class="block w-full text-center sm:inline-block sm:w-auto mt-3 px-4 py-2 bg-white text-black rounded shadow hover:bg-gray-100 transition">
-              Visit Sanaa Media
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Second row -->
     <div class="row gy-4">
-      <!-- Oyes -->
-      <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInLeftShorter" data-appear-animation-delay="300">
-        <div class="feature-box feature-box-style-2 h-100">
-          <div class="feature-box-icon"></div>
-          <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">Oyes</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              Logistics service for the delivery of goods from and through a network of local partners and suppliers on our various marketplaces, solving one of the biggest logistical hurdles hindering the e‑commerce industry on the continent.
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <!-- WOO + -->
+      @foreach(\App\Models\Offering::all() as $offering)
       <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInUpShorter">
         <div class="feature-box feature-box-style-2 h-100">
           <div class="feature-box-icon"></div>
           <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">WOO +</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              WOO+ is a line of digital media player software programs developed by Sanaa aimed at subscription‑based streaming services that allow members to watch high‑quality, original African TV shows and movies, ad‑free, on Internet‑connected devices.
-            </p>
+            <h4 class="font-weight-bold text-color-black text-4 mb-2">{{ $offering->title }}</h4>
+            <p class="text-color-black opacity-7 flex-grow-1">{{ $offering->description }}</p>
+            @if($offering->link)
+              <a href="{{ $offering->link }}" target="_blank" class="block w-full text-center sm:inline-block sm:w-auto mt-3 px-4 py-2 bg-white text-black rounded shadow hover:bg-gray-100 transition">
+                Visit {{ $offering->title }}
+              </a>
+            @endif
           </div>
         </div>
       </div>
-
-      <!-- ilé -->
-      <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInRightShorter" data-appear-animation-delay="300">
-        <div class="feature-box feature-box-style-2 h-100">
-          <div class="feature-box-icon">
-            <i class="icons icon-screen-paypal text-color-black"></i>
-          </div>
-          <div class="feature-box-info d-flex flex-column h-100">
-            <h4 class="font-weight-bold text-color-black text-4 mb-2">ilé</h4>
-            <p class="text-color-black opacity-7 flex-grow-1">
-              Online real estate marketplace where tenants & owners meet to find properties for sale or rent: houses, apartments, building plots, garages, offices, shops and industrial premises—from new constructions to exceptional historical buildings—all across Africa.
-            </p>
-          </div>
-        </div>
-      </div>
+      @endforeach
     </div>
   </div>
 </section>

--- a/resources/views/pages/products.blade.php
+++ b/resources/views/pages/products.blade.php
@@ -6,7 +6,21 @@
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Products</h1>
-            <p class="mt-4 text-gray-600">Product listings will appear here soon.</p>
+            @if($items->count())
+                <ul class="mt-4 space-y-2">
+                    @foreach($items as $item)
+                        <li class="border-b pb-2">
+                            <h2 class="font-semibold">{{ $item->title }}</h2>
+                            <p class="text-gray-600">{{ $item->description }}</p>
+                            @if($item->link)
+                                <a href="{{ $item->link }}" class="text-primary underline" target="_blank">Visit</a>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <p class="mt-4 text-gray-600">Product listings will appear here soon.</p>
+            @endif
         </div>
     </section>
 

--- a/resources/views/pages/services.blade.php
+++ b/resources/views/pages/services.blade.php
@@ -6,7 +6,21 @@
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Services</h1>
-            <p class="mt-4 text-gray-600">Service information will be added soon.</p>
+            @if($items->count())
+                <ul class="mt-4 space-y-2">
+                    @foreach($items as $item)
+                        <li class="border-b pb-2">
+                            <h2 class="font-semibold">{{ $item->title }}</h2>
+                            <p class="text-gray-600">{{ $item->description }}</p>
+                            @if($item->link)
+                                <a href="{{ $item->link }}" class="text-primary underline" target="_blank">Learn more</a>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <p class="mt-4 text-gray-600">Service information will be added soon.</p>
+            @endif
         </div>
     </section>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,8 @@ Route::get('/policy', [PageController::class, 'policy'])->name('policy');
 Route::get('/company', [PageController::class, 'company'])->name('company');
 Route::get('/support', [PageController::class, 'support'])->name('support');
 Route::post('/support', [SupportController::class, 'send'])->name('support.send');
-Route::get('/products', [PageController::class, 'products'])->name('products');
-Route::get('/services', [PageController::class, 'services'])->name('services');
+Route::get('/products', [\App\Http\Controllers\OfferingController::class, 'index'])->defaults('type', 'product')->name('products');
+Route::get('/services', [\App\Http\Controllers\OfferingController::class, 'index'])->defaults('type', 'service')->name('services');
 Route::get('/bulk-sms', [PageController::class, 'bulkSms'])->name('bulk-sms');
 Route::get('/prices', [PageController::class, 'prices'])->name('prices');
 Route::get('/careers', [CareerController::class, 'index'])->name('careers');
@@ -102,6 +102,11 @@ Route::middleware([
         return view('dashboard.prices');
     })->name('dashboard.prices');
 
+    Route::get('/dashboard/offerings', function () {
+        $items = \App\Models\Offering::all();
+        return view('dashboard.offerings', compact('items'));
+    })->name('dashboard.offerings');
+
     Route::get('/dashboard/policies', function () {
         $terms = Policy::where('key', 'terms')->first();
         $seller = Policy::where('key', 'seller-policies')->first();
@@ -109,6 +114,8 @@ Route::middleware([
     })->name('dashboard.policies');
 
     Route::post('/dashboard/blog', [BlogController::class, 'store'])->name('dashboard.blog.store');
+    Route::put('/dashboard/blog/{blog}', [BlogController::class, 'update'])->name('dashboard.blog.update');
+    Route::delete('/dashboard/blog/{blog}', [BlogController::class, 'destroy'])->name('dashboard.blog.destroy');
     Route::post('/dashboard/category', [\App\Http\Controllers\BusinessCategoryController::class, 'store'])->name('dashboard.category.store');
     Route::post('/dashboard/team', [TeamController::class, 'store'])->name('dashboard.team.store');
     Route::put('/dashboard/team/{member}', [TeamController::class, 'update'])->name('dashboard.team.update');
@@ -119,4 +126,8 @@ Route::middleware([
     Route::post('/dashboard/hardware-rental', [HardwareRentalController::class, 'store'])->name('dashboard.hardware-rental.store');
     Route::post('/dashboard/price', [PriceController::class, 'store'])->name('dashboard.price.store');
     Route::post('/dashboard/policy/{key}', [PolicyController::class, 'update'])->name('dashboard.policy.update');
+
+    Route::post('/dashboard/offering', [\App\Http\Controllers\OfferingController::class, 'store'])->name('dashboard.offering.store');
+    Route::put('/dashboard/offering/{offering}', [\App\Http\Controllers\OfferingController::class, 'update'])->name('dashboard.offering.update');
+    Route::delete('/dashboard/offering/{offering}', [\App\Http\Controllers\OfferingController::class, 'destroy'])->name('dashboard.offering.destroy');
 });


### PR DESCRIPTION
## Summary
- enable admin CRUD for blog posts
- add admin module for products & services (offerings)
- show offerings on landing pages
- expose offerings routes

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b108d52c88324bbe3e49a3352d113