### PR TITLE
Add offering seeder and show snapshot on home

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Database\Seeders\BlogSeeder;
 use Database\Seeders\TeamMemberSeeder;
+use Database\Seeders\OfferingSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -25,6 +26,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             BlogSeeder::class,
             TeamMemberSeeder::class,
+            OfferingSeeder::class,
         ]);
     }
 }

--- a/database/seeders/OfferingSeeder.php
+++ b/database/seeders/OfferingSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Offering;
+
+class OfferingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Offering::truncate();
+
+        $data = [
+            [
+                'title' => 'Soko 24',
+                'type' => 'product',
+                'description' => 'Our online shopping destination with authentic brands and essentials.',
+                'link' => 'https://soko.sanaa.co',
+            ],
+            [
+                'title' => 'Sanaa Fi',
+                'type' => 'service',
+                'description' => 'Reliable financial solutions for businesses across Africa.',
+                'link' => 'https://fin.sanaa.co',
+            ],
+            [
+                'title' => 'Sanaa Media',
+                'type' => 'service',
+                'description' => 'Helping creators build digital media brands across the continent.',
+                'link' => 'https://media.sanaa.co',
+            ],
+        ];
+
+        foreach ($data as $item) {
+            Offering::create($item);
+        }
+    }
+}

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="row gy-4">
-      @foreach(\App\Models\Offering::all() as $offering)
+      @forelse(\App\Models\Offering::latest()->take(3)->get() as $offering)
       <div class="col-12 col-lg-4 appear-animation" data-appear-animation="fadeInUpShorter">
         <div class="feature-box feature-box-style-2 h-100">
           <div class="feature-box-icon"></div>
@@ -44,7 +44,11 @@
           </div>
         </div>
       </div>
-      @endforeach
+      @empty
+      <div class="col-12 text-center">
+        <p class="text-color-black opacity-7">Offerings will be added soon.</p>
+      </div>
+      @endforelse
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- seed sample offerings
- include `OfferingSeeder` in `DatabaseSeeder`
- limit home page to show the latest 3 offerings with a fallback message

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b225a1cf88324bb3e8b3bc3e3877b