### PR TITLE
Add Read More links to blog previews

### DIFF
--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -16,6 +16,7 @@
                         <a href="{{ route('blog.show', $post->slug) }}" class="hover:underline">{{ $post->title }}</a>
                     </h2>
                     <p class="text-gray-700 text-sm">{{ $post->excerpt }}</p>
+                    <a href="{{ route('blog.show', $post->slug) }}" class="text-primary hover:underline mt-2 inline-block">Read More</a>
                 </div>
             </div>
         @endforeach

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -279,6 +279,7 @@
                 <a href="{{ route('blog.show', $blog->slug) }}" class="hover:underline">{{ $blog->title }}</a>
               </h3>
               <p class="text-sm text-gray-700">{{ $blog->excerpt }}</p>
+              <a href="{{ route('blog.show', $blog->slug) }}" class="text-primary hover:underline mt-2 inline-block">Read More</a>
             </div>
           </div>
           @endforeach


### PR DESCRIPTION
## Summary
- Add "Read More" link to each blog card on the home page
- Expose "Read More" link on blog index cards for direct navigation to full posts

## Testing
- `php artisan test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2726d3ca88324bcc56d0a5ba86d74