### PR TITLE
Render blog posts with Markdown

### DIFF
--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -9,7 +9,7 @@
         @if($post->image)
             <img src="{{ asset('storage/'.$post->image) }}" alt="{{ $post->title }}" class="rounded-lg mb-6">
         @endif
-        {!! nl2br(e($post->body)) !!}
+        {!! Illuminate\Support\Str::markdown($post->body) !!}
     </article>
 </div>
 @endsection

--- a/tests/Feature/BlogMarkdownTest.php
+++ b/tests/Feature/BlogMarkdownTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use Tests\TestCase;
+
+class BlogMarkdownTest extends TestCase
+{
+    public function test_blog_body_renders_markdown()
+    {
+        $post = new Blog([
+            'title' => 'Markdown Post',
+            'slug' => 'markdown-post',
+            'body' => '**bold** _italic_',
+        ]);
+
+        $view = $this->view('blog.show', ['post' => $post]);
+
+        $view->assertSee('<strong>bold</strong>', false);
+        $view->assertSee('<em>italic</em>', false);
+    }
+}


### PR DESCRIPTION
## Summary
- Render blog post bodies using Markdown for richer formatting
- Add feature test to verify Markdown conversion

## Testing
- `npm run a11y` *(fails: connect ECONNREFUSED)*
- `composer test` *(fails: vendor/bin/pest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27f689a78832485b0a71afc8bee51