### PR TITLE
Refactor hero CTA buttons to use shared styles

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -16,4 +16,7 @@
     .btn-cta {
         @apply px-8 py-3 rounded-md font-semibold bg-white text-black dark:bg-green-600 dark:text-white transition transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-green-500;
     }
+    .btn-cta-outline {
+        @apply px-8 py-3 rounded-md font-semibold border border-white text-white bg-transparent hover:bg-white hover:text-black transition transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-green-500;
+    }
 }

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -20,7 +20,7 @@
           </p>
           <div class="flex flex-col sm:flex-row justify-center gap-4">
             <a href="#services" class="btn-cta">Explore Sanaa</a>
-            <a href="https://soko.sanaa.co" target="_blank" class="btn-cta bg-transparent border border-white text-white hover:bg-white hover:text-black">Shop on Soko 24</a>
+            <a href="https://soko.sanaa.co" target="_blank" class="btn-cta-outline">Shop on Soko 24</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add reusable `btn-cta-outline` class for outline-style call-to-action buttons
- Simplify hero CTA markup to use the new outline class

## Testing
- `npm run a11y` *(fails: connect ECONNREFUSED 127.0.0.1:8000)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2977bd3a88324878fa97467fe047a