### PR TITLE
Add blog API and engagement metrics

### DIFF
--- a/app/Http/Controllers/Api/BlogController.php
+++ b/app/Http/Controllers/Api/BlogController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Blog;
+use Illuminate\Http\Request;
+
+class BlogController extends Controller
+{
+    public function index()
+    {
+        return Blog::select('id','title','slug','excerpt','created_at','views','likes','shares','saves')->orderByDesc('created_at')->get();
+    }
+
+    public function show(Blog $blog)
+    {
+        $blog->increment('views');
+        return $blog;
+    }
+
+    public function like(Blog $blog)
+    {
+        $blog->increment('likes');
+        return response()->json(['likes' => $blog->likes]);
+    }
+
+    public function share(Blog $blog)
+    {
+        $blog->increment('shares');
+        return response()->json(['shares' => $blog->shares]);
+    }
+
+    public function save(Blog $blog)
+    {
+        $blog->increment('saves');
+        return response()->json(['saves' => $blog->saves]);
+    }
+}

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -20,6 +20,7 @@ class BlogController extends Controller
     public function show(string $slug)
     {
         $post = Blog::where('slug', $slug)->firstOrFail();
+        $post->increment('views');
         return view('blog.show', compact('post'));
     }
  

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -2,15 +2,22 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Blog extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'slug',
         'excerpt',
         'body',
         'image',
+        'views',
+        'likes',
+        'shares',
+        'saves',
     ];
 }

--- a/database/factories/BlogFactory.php
+++ b/database/factories/BlogFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Blog;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class BlogFactory extends Factory
+{
+    protected $model = Blog::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence;
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title),
+            'excerpt' => $this->faker->paragraph,
+            'body' => $this->faker->paragraph,
+        ];
+    }
+}

--- a/database/migrations/2025_07_14_000000_add_metrics_to_blogs_table.php
+++ b/database/migrations/2025_07_14_000000_add_metrics_to_blogs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->unsignedBigInteger('views')->default(0);
+            $table->unsignedBigInteger('likes')->default(0);
+            $table->unsignedBigInteger('shares')->default(0);
+            $table->unsignedBigInteger('saves')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->dropColumn(['views', 'likes', 'shares', 'saves']);
+        });
+    }
+};

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -6,6 +6,30 @@
 <div class="container mx-auto py-12 px-4 max-w-4xl">
     <article class="prose lg:prose-lg">
         <h1>{{ $post->title }}</h1>
+        <div class="text-sm text-gray-500 mb-4 flex items-center space-x-2">
+            <span>{{ $post->created_at->format('M d') }}</span>
+            <span>•</span>
+            <span><span id="views-count">{{ $post->views }}</span> views</span>
+            <span>•</span>
+            <span><span id="likes-count">{{ $post->likes }}</span> likes</span>
+            <span>•</span>
+            <span><span id="shares-count">{{ $post->shares }}</span> shares</span>
+        </div>
+        <div class="flex items-center space-x-4 mb-6">
+            <button id="like-button" class="text-primary">Like</button>
+            <button id="share-button" class="text-primary">Share</button>
+            <button id="save-button" class="text-primary">Save</button>
+            <div class="relative">
+                <button id="more-button" class="text-primary">More</button>
+                <div id="more-menu" class="hidden absolute right-0 mt-2 bg-white border rounded shadow-lg text-sm">
+                    <a href="#" class="block px-4 py-2">Follow author</a>
+                    <a href="#" class="block px-4 py-2">Follow publication</a>
+                    <a href="#" class="block px-4 py-2">Mute author</a>
+                    <a href="#" class="block px-4 py-2">Mute publication</a>
+                    <a href="#" class="block px-4 py-2">Report story</a>
+                </div>
+            </div>
+        </div>
         @if($post->image)
             <img src="{{ asset('storage/'.$post->image) }}" alt="{{ $post->title }}" class="rounded-lg mb-6">
         @endif
@@ -13,3 +37,30 @@
     </article>
 </div>
 @endsection
+
+@push('scripts')
+<script>
+async function post(path) {
+    const res = await fetch(path, {method: 'POST', headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}'}});
+    return res.json();
+}
+
+document.getElementById('like-button').addEventListener('click', async () => {
+    const data = await post('/api/blogs/{{ $post->id }}/like');
+    document.getElementById('likes-count').innerText = data.likes;
+});
+
+document.getElementById('share-button').addEventListener('click', async () => {
+    const data = await post('/api/blogs/{{ $post->id }}/share');
+    document.getElementById('shares-count').innerText = data.shares;
+});
+
+document.getElementById('save-button').addEventListener('click', async () => {
+    await post('/api/blogs/{{ $post->id }}/save');
+});
+
+document.getElementById('more-button').addEventListener('click', () => {
+    document.getElementById('more-menu').classList.toggle('hidden');
+});
+</script>
+@endpush

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,14 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\BlogController;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::get('/blogs', [BlogController::class, 'index']);
+Route::get('/blogs/{blog:slug}', [BlogController::class, 'show']);
+Route::post('/blogs/{blog}/like', [BlogController::class, 'like']);
+Route::post('/blogs/{blog}/share', [BlogController::class, 'share']);
+Route::post('/blogs/{blog}/save', [BlogController::class, 'save']);

--- a/tests/Feature/BlogApiTest.php
+++ b/tests/Feature/BlogApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_endpoint_increments_views(): void
+    {
+        $post = Blog::factory()->create();
+
+        $this->getJson("/api/blogs/{$post->slug}")->assertOk();
+
+        $this->assertEquals(1, $post->fresh()->views);
+    }
+
+    public function test_like_endpoint_increments_likes(): void
+    {
+        $post = Blog::factory()->create();
+
+        $this->postJson("/api/blogs/{$post->id}/like")->assertOk()->assertJson(['likes' => 1]);
+
+        $this->assertEquals(1, $post->fresh()->likes);
+    }
+}


### PR DESCRIPTION
## Summary
- add API endpoints for blog posts with view, like, share and save counters
- track engagement metrics on blogs and increment views
- show publish date and engagement buttons on blog page with "More" dropdown

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d44ad5508324a9050f087bfbb857