### PR TITLE
Use slug-based blog interaction endpoints

### DIFF
--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
         likeBtn.addEventListener('click', async () => {
             likeBtn.disabled = true;
             try {
-                const data = await post('/api/blogs/{{ $post->id }}/like');
+                const data = await post('/api/blogs/{{ $post->slug }}/like');
                 document.getElementById('likes-count').innerText = data.likes;
                 animate(likeBtn);
             } catch (err) {
@@ -81,7 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
         shareBtn.addEventListener('click', async () => {
             shareBtn.disabled = true;
             try {
-                const data = await post('/api/blogs/{{ $post->id }}/share');
+                const data = await post('/api/blogs/{{ $post->slug }}/share');
                 document.getElementById('shares-count').innerText = data.shares;
                 animate(shareBtn);
             } catch (err) {
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
         saveBtn.addEventListener('click', async () => {
             saveBtn.disabled = true;
             try {
-                const data = await post('/api/blogs/{{ $post->id }}/save');
+                const data = await post('/api/blogs/{{ $post->slug }}/save');
                 document.getElementById('saves-count').innerText = data.saves;
                 saveBtn.textContent = 'Saved';
                 animate(saveBtn);

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,6 @@ Route::get('/user', function (Request $request) {
 
 Route::get('/blogs', [BlogController::class, 'index']);
 Route::get('/blogs/{blog:slug}', [BlogController::class, 'show']);
-Route::post('/blogs/{blog}/like', [BlogController::class, 'like']);
-Route::post('/blogs/{blog}/share', [BlogController::class, 'share']);
-Route::post('/blogs/{blog}/save', [BlogController::class, 'save']);
+Route::post('/blogs/{blog:slug}/like', [BlogController::class, 'like']);
+Route::post('/blogs/{blog:slug}/share', [BlogController::class, 'share']);
+Route::post('/blogs/{blog:slug}/save', [BlogController::class, 'save']);

--- a/tests/Feature/BlogApiTest.php
+++ b/tests/Feature/BlogApiTest.php
@@ -23,7 +23,7 @@ class BlogApiTest extends TestCase
     {
         $post = Blog::factory()->create();
 
-        $this->postJson("/api/blogs/{$post->id}/like")->assertOk()->assertJson(['likes' => 1]);
+        $this->postJson("/api/blogs/{$post->slug}/like")->assertOk()->assertJson(['likes' => 1]);
 
         $this->assertEquals(1, $post->fresh()->likes);
     }


### PR DESCRIPTION
## Summary
- Switch blog interaction routes (like/share/save) to use slugs instead of numeric IDs
- Adjust blog page script to post to slug-based endpoints
- Update API tests to exercise slug-based like endpoint

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because composer dependencies not installed)*
- `npm run a11y` *(fails: connect ECONNREFUSED to localhost:8000)*


------
https://chatgpt.com/codex/tasks/task_e_68a6279782288324a94be85a1772c882