### PR TITLE
Add Medium-style blog migrations with categories, analytics, and tags

### DIFF
--- a/database/migrations/2025_08_21_000001_enhance_blogs_table_for_medium_style.php
+++ b/database/migrations/2025_08_21_000001_enhance_blogs_table_for_medium_style.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            // Add missing columns for Medium-style blog
+            if (!Schema::hasColumn('blogs', 'featured_image')) {
+                $table->string('featured_image')->nullable()->after('body');
+            }
+            if (!Schema::hasColumn('blogs', 'author_id')) {
+                $table->foreignId('author_id')->nullable()->constrained('users')->onDelete('set null')->after('featured_image');
+            }
+            if (!Schema::hasColumn('blogs', 'status')) {
+                $table->enum('status', ['draft', 'published', 'archived'])->default('draft')->after('author_id');
+            }
+            if (!Schema::hasColumn('blogs', 'featured')) {
+                $table->boolean('featured')->default(false)->after('status');
+            }
+            if (!Schema::hasColumn('blogs', 'published_at')) {
+                $table->timestamp('published_at')->nullable()->after('featured');
+            }
+            if (!Schema::hasColumn('blogs', 'reading_time')) {
+                $table->integer('reading_time')->nullable()->after('published_at');
+            }
+            if (!Schema::hasColumn('blogs', 'bookmarks')) {
+                $table->unsignedBigInteger('bookmarks')->default(0)->after('saves');
+            }
+            if (!Schema::hasColumn('blogs', 'meta_title')) {
+                $table->string('meta_title')->nullable()->after('bookmarks');
+            }
+            if (!Schema::hasColumn('blogs', 'meta_description')) {
+                $table->text('meta_description')->nullable()->after('meta_title');
+            }
+            if (!Schema::hasColumn('blogs', 'keywords')) {
+                $table->text('keywords')->nullable()->after('meta_description');
+            }
+            if (!Schema::hasColumn('blogs', 'category_id')) {
+                $table->foreignId('category_id')->nullable()->constrained('blog_categories')->onDelete('set null')->after('keywords');
+            }
+
+            // Add indexes for performance
+            $table->index(['status', 'published_at']);
+            $table->index(['featured', 'published_at']);
+            $table->index('views');
+            $table->index('likes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('blogs', function (Blueprint $table) {
+            $table->dropForeign(['author_id']);
+            $table->dropForeign(['category_id']);
+            $table->dropIndex(['status', 'published_at']);
+            $table->dropIndex(['featured', 'published_at']);
+            $table->dropIndex(['views']);
+            $table->dropIndex(['likes']);
+
+            $table->dropColumn([
+                'featured_image', 'author_id', 'status', 'featured',
+                'published_at', 'reading_time', 'bookmarks',
+                'meta_title', 'meta_description', 'keywords', 'category_id',
+            ]);
+        });
+    }
+};
+

--- a/database/migrations/2025_08_21_000002_create_blog_categories_table.php
+++ b/database/migrations/2025_08_21_000002_create_blog_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blog_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('color', 7)->default('#00ff00'); // Green accent color
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        // Seed default categories
+        DB::table('blog_categories')->insert([
+            ['name' => 'Technology', 'slug' => 'technology', 'description' => 'Latest in tech and innovation', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'Business', 'slug' => 'business', 'description' => 'Business insights and strategies', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'Design', 'slug' => 'design', 'description' => 'Design principles and aesthetics', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'Innovation', 'slug' => 'innovation', 'description' => 'Innovative ideas and solutions', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_categories');
+    }
+};
+

--- a/database/migrations/2025_08_21_000003_create_blog_analytics_table.php
+++ b/database/migrations/2025_08_21_000003_create_blog_analytics_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blog_analytics', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('blog_id')->nullable()->constrained()->onDelete('cascade');
+            $table->string('ip_address', 45);
+            $table->text('user_agent')->nullable();
+            $table->string('referrer', 500)->nullable();
+            $table->string('event_type'); // page_view, like, bookmark, share, scroll_depth, reading_time
+            $table->json('metadata')->nullable(); // Store additional data like scroll percentage, time spent, etc.
+            $table->integer('value')->nullable(); // For numerical values like scroll depth percentage
+            $table->timestamps();
+
+            $table->index(['blog_id', 'event_type']);
+            $table->index('created_at');
+            $table->index(['ip_address', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_analytics');
+    }
+};
+

--- a/database/migrations/2025_08_21_000004_create_blog_tags_table.php
+++ b/database/migrations/2025_08_21_000004_create_blog_tags_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('blog_tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('color', 7)->default('#00ff00');
+            $table->timestamps();
+        });
+
+        Schema::create('blog_tag_pivot', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('blog_id')->constrained()->onDelete('cascade');
+            $table->foreignId('blog_tag_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['blog_id', 'blog_tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_tag_pivot');
+        Schema::dropIfExists('blog_tags');
+    }
+};
+


### PR DESCRIPTION
## Summary
- extend blogs table with Medium-style fields and indices
- create blog category model with default seed data
- track blog analytics events and add tagging support

## Testing
- `composer update pestphp/pest pestphp/pest-plugin-laravel` *(fails: Root composer.json requires pestphp/pest ^2.30 -> phpunit/phpunit version conflict)*
- `composer install --no-dev`
- `php artisan test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a649d8221c8324b5716bc40d29f952