### PR TITLE
Fix blog index filtering for posts without published dates

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -18,7 +18,8 @@ class BlogController extends Controller
         $query = Blog::with(['author', 'category', 'tags'])
             ->published()
             ->orderByDesc('featured')
-            ->orderByDesc('published_at');
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at');
 
         // Handle category filtering
         if ($request->has('category') && $request->category) {

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -49,7 +49,10 @@ class Blog extends Model
     public function scopePublished($query)
     {
         return $query->where('status', 'published')
-                    ->where('published_at', '<=', now());
+                    ->where(function($q) {
+                        $q->whereNull('published_at')
+                          ->orWhere('published_at', '<=', now());
+                    });
     }
 
     public function scopeFeatured($query)

--- a/tests/Feature/BlogIndexTest.php
+++ b/tests/Feature/BlogIndexTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_displays_published_posts_without_published_date()
+    {
+        $post = Blog::factory()->create([
+            'title' => 'Missing Date Post',
+            'status' => 'published',
+            'published_at' => null,
+        ]);
+
+        $response = $this->get(route('blog.index'));
+
+        $response->assertOk();
+        $response->assertSee('Missing Date Post');
+    }
+}


### PR DESCRIPTION
## Summary
- Include blogs missing `published_at` in `published()` scope
- Ensure blog index sorts posts by published or created date
- Add feature test covering posts without published dates

## Testing
- `composer install` *(failed: lock file out of date and required packages missing)*
- `php artisan test` *(failed: missing vendor autoload file)*

------
https://chatgpt.com/codex/tasks/task_e_68a662bb064883248fd69a53e96d9da1