### PR TITLE
Fix service icon rendering

### DIFF
--- a/resources/views/dashboard/services/index.blade.php
+++ b/resources/views/dashboard/services/index.blade.php
@@ -45,7 +45,7 @@
                             <div class="flex items-start gap-4">
                                 @if($service->icon)
                                     <div class="flex items-center justify-center w-12 h-12 bg-emerald-100 rounded-lg">
-                                        <i class="text-emerald-600 text-xl">{{ $service->icon }}</i>
+                                        <i class="text-emerald-600 text-xl {{ $service->icon }}"></i>
                                     </div>
                                 @endif
                                 <div class="flex-1">

--- a/resources/views/dashboard/services/show.blade.php
+++ b/resources/views/dashboard/services/show.blade.php
@@ -22,7 +22,7 @@
                     <div class="flex items-center gap-4">
                         @if($service->icon)
                             <div class="flex items-center justify-center w-16 h-16 bg-emerald-100 rounded-lg">
-                                <i class="text-emerald-600 text-2xl">{{ $service->icon }}</i>
+                                <i class="text-emerald-600 text-2xl {{ $service->icon }}"></i>
                             </div>
                         @endif
                         <div>

--- a/resources/views/pages/services.blade.php
+++ b/resources/views/pages/services.blade.php
@@ -263,7 +263,7 @@
                                 <div class="relative mb-6">
                                     @if($service->icon)
                                         <div class="flex items-center justify-center w-16 h-16 bg-gradient-to-br from-emerald-50 to-emerald-100 rounded-2xl group-hover:from-emerald-100 group-hover:to-emerald-200 transition-all duration-500 group-hover:scale-110 group-hover:rotate-3">
-                                            <i class="text-emerald-600 text-2xl group-hover:scale-110 transition-transform duration-300">{{ $service->icon }}</i>
+                                            <i class="text-emerald-600 text-2xl group-hover:scale-110 transition-transform duration-300 {{ $service->icon }}"></i>
                                         </div>
                                     @else
                                         <div class="flex items-center justify-center w-16 h-16 bg-gradient-to-br from-emerald-50 to-emerald-100 rounded-2xl group-hover:from-emerald-100 group-hover:to-emerald-200 transition-all duration-500 group-hover:scale-110 group-hover:rotate-3">


### PR DESCRIPTION
## Summary
- display service icons by applying Font Awesome classes to `<i>` elements

## Testing
- `APP_KEY=base64:ojGCTisXn400k35CMy8EBScSLnwpF5jAYCqajXwHowo= DB_CONNECTION=sqlite DB_DATABASE=database/database.sqlite composer test` *(fails: Undefined variable $blog)*


------
https://chatgpt.com/codex/tasks/task_e_68c0ea3cb3208324bab0ab1848142bea