### PR TITLE
Throttle contact form submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ It is built with [Laravel](https://laravel.com/) and uses Jetstream for authenti
 - Dynamic product listing pulled from Soko 24
 - Placeholder pages for company information, services and more
 
+## Contact Form Rate Limiting
+
+The `/contact` endpoint is protected by Laravel's `throttle` middleware and allows up to five submissions per minute per IP address. Users who exceed this limit will receive a **429 Too Many Requests** response and should wait before trying again.
+
 ## Upcoming Menu Items
 
 - [ ] Ai branding

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -17,12 +17,17 @@ class ContactController extends Controller
 
     public function store(Request $request)
     {
-        $data = $request->validate([
+        $request->validate([
             'name' => 'required',
             'email' => 'required|email',
             'message' => 'nullable',
+            'website' => 'present|size:0',
         ]);
+
+        $data = $request->only('name', 'email', 'message');
+
         Contact::create($data);
+
         Mail::to('agumabanksibrahim@gmail.com')->send(
             new ContactMessage(
                 $data['name'],

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -330,7 +330,8 @@
 
                         <form action="{{ route('contact.store') }}" method="POST" class="space-y-6">
                             @csrf
-                            
+                            <input type="text" name="website" id="website" class="hidden" tabindex="-1" autocomplete="off">
+
                             <div class="grid sm:grid-cols-2 gap-6">
                                 <!-- Name -->
                                 <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,9 @@ Route::prefix('policies')->name('policies.')->group(function () {
 Route::get('/developer-platforms', [DeveloperPlatformController::class, 'index'])->name('developer-platforms');
 Route::get('/rent-hardware', [HardwareRentalController::class, 'index'])->name('rent-hardware');
 Route::get('/contact', [ContactController::class, 'index'])->name('contact');
-Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');
+Route::post('/contact', [ContactController::class, 'store'])
+    ->middleware('throttle:5,1')
+    ->name('contact.store');
 
 // Blog routes
 Route::prefix('blog')->name('blog.')->group(function () {


### PR DESCRIPTION
## Summary
- rate limit POST /contact to five requests per minute
- add honeypot field to contact form and validate it server-side
- document contact form rate limit in README

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d670b2a08324ad90ac2abaf55f88