### PR TITLE
feat: enable conditional firebase analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ It is built with [Laravel](https://laravel.com/) and uses Jetstream for authenti
    php artisan serve
    ```
 
+## Analytics
+
+Firebase analytics is optional and loaded only on pages that opt in. To enable it for a Blade view that extends `layouts.app`, declare an empty `analytics` section:
+
+```blade
+@extends('layouts.app')
+
+@section('analytics')
+@endsection
+```
+
+The layout detects this section and dynamically imports the Firebase SDK after `DOMContentLoaded`, ensuring that analytics does not block page rendering.
+
 ## Testing
 
 Run the automated test suite with:

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,32 +46,28 @@
         @stack('modals')
 
         @livewireScripts
-        
-<!-- sanaa google tag -->
- 
 
-<script type="module">
-  // Import the functions you need from the SDKs you need
-  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.4.0/firebase-app.js";
-  import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.4.0/firebase-analytics.js";
-  // TODO: Add SDKs for Firebase products that you want to use
-  // https://firebase.google.com/docs/web/setup#available-libraries
+        <!-- Firebase Analytics -->
+        @hasSection('analytics')
+            <script defer>
+                window.addEventListener('DOMContentLoaded', async () => {
+                    const { initializeApp } = await import('https://www.gstatic.com/firebasejs/11.4.0/firebase-app.js');
+                    const { getAnalytics } = await import('https://www.gstatic.com/firebasejs/11.4.0/firebase-analytics.js');
 
-  // Your web app's Firebase configuration
-  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-  const firebaseConfig = {
-    apiKey: "{{ config('services.firebase.api_key') }}",
-    authDomain: "{{ config('services.firebase.auth_domain') }}",
-    projectId: "{{ config('services.firebase.project_id') }}",
-    storageBucket: "{{ config('services.firebase.storage_bucket') }}",
-    messagingSenderId: "{{ config('services.firebase.messaging_sender_id') }}",
-    appId: "{{ config('services.firebase.app_id') }}",
-    measurementId: "{{ config('services.firebase.measurement_id') }}"
-  };
+                    const firebaseConfig = {
+                        apiKey: "{{ config('services.firebase.api_key') }}",
+                        authDomain: "{{ config('services.firebase.auth_domain') }}",
+                        projectId: "{{ config('services.firebase.project_id') }}",
+                        storageBucket: "{{ config('services.firebase.storage_bucket') }}",
+                        messagingSenderId: "{{ config('services.firebase.messaging_sender_id') }}",
+                        appId: "{{ config('services.firebase.app_id') }}",
+                        measurementId: "{{ config('services.firebase.measurement_id') }}"
+                    };
 
-  // Initialize Firebase
-  const app = initializeApp(firebaseConfig);
-  const analytics = getAnalytics(app);
-</script>
+                    const app = initializeApp(firebaseConfig);
+                    getAnalytics(app);
+                });
+            </script>
+        @endif
     </body>
 </html>


### PR DESCRIPTION
## Summary
- load Firebase analytics only when a view declares an `analytics` section
- dynamically import Firebase modules after `DOMContentLoaded` to avoid blocking rendering
- document how to opt-in to analytics from Blade views

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d650abc88324b1c441cedeb5249a