### PR TITLE
Cache small listings and paginate admin services

### DIFF
--- a/app/Http/Controllers/CareerController.php
+++ b/app/Http/Controllers/CareerController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Career;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class CareerController extends Controller
 {
     public function index()
     {
-        $items = Career::all();
+        // Career postings are limited (<100); cache for 30 minutes
+        $items = Cache::remember('careers', 1800, fn() => Career::all());
         return view('pages.careers', compact('items'));
     }
 

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\Contact;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Cache;
 use App\Mail\ContactMessage;
 
 class ContactController extends Controller
 {
     public function index()
     {
-        $items = Contact::all();
+        // Contact methods are few (<10); cache for 1 hour
+        $items = Cache::remember('contacts', 3600, fn() => Contact::all());
         return view('pages.contact', compact('items'));
     }
 

--- a/app/Http/Controllers/DeveloperPlatformController.php
+++ b/app/Http/Controllers/DeveloperPlatformController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\DeveloperPlatform;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class DeveloperPlatformController extends Controller
 {
     public function index()
     {
-        $items = DeveloperPlatform::all();
+        // Developer platforms are limited (<20); cache for 1 hour
+        $items = Cache::remember('developer_platforms', 3600, fn() => DeveloperPlatform::all());
         return view('pages.developer-platforms', compact('items'));
     }
 

--- a/app/Http/Controllers/HardwareRentalController.php
+++ b/app/Http/Controllers/HardwareRentalController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\HardwareRental;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class HardwareRentalController extends Controller
 {
     public function index()
     {
-        $items = HardwareRental::all();
+        // Hardware rental catalog is small (<50); cache for 1 hour
+        $items = Cache::remember('hardware_rentals', 3600, fn() => HardwareRental::all());
         return view('pages.rent-hardware', compact('items'));
     }
 

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Cache;
+use App\Models\TeamMember;
 
 
 class PageController extends Controller
@@ -26,7 +27,8 @@ class PageController extends Controller
         } catch (\Throwable $e) {
             $sokoProducts = $this->fallbackSokoProducts();
         }
-        $teamMembers = \App\Models\TeamMember::all();
+        // Team members rarely change; cache for 1 hour
+        $teamMembers = Cache::remember('team_members', 3600, fn() => TeamMember::all());
         return view('pages.home', [
             'sokoProducts' => $sokoProducts,
             'teamMembers' => $teamMembers,

--- a/app/Http/Controllers/PartnerController.php
+++ b/app/Http/Controllers/PartnerController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Partner;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class PartnerController extends Controller
 {
     public function index()
     {
-        $items = Partner::all();
+        // Partner list is expected to stay under 50 records so cache for an hour
+        $items = Cache::remember('partners', 3600, fn() => Partner::all());
         return view('pages.partners', compact('items'));
     }
 

--- a/app/Http/Controllers/PolicyController.php
+++ b/app/Http/Controllers/PolicyController.php
@@ -169,10 +169,12 @@ class PolicyController extends Controller
         }
 
         // Clear all policy caches
-        $policies = Policy::all();
-        foreach ($policies as $policy) {
-            Cache::forget("policy_{$policy->key}");
+        // Policy count is modest (<100), cache the list of keys for an hour
+        $policyKeys = Cache::remember('policy_keys', 3600, fn() => Policy::pluck('key'));
+        foreach ($policyKeys as $key) {
+            Cache::forget("policy_{$key}");
         }
+        Cache::forget('policy_keys');
 
         return response()->json(['success' => true, 'message' => 'Policies updated successfully']);
     }

--- a/app/Http/Controllers/PriceController.php
+++ b/app/Http/Controllers/PriceController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Price;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class PriceController extends Controller
 {
     public function index()
     {
-        $items = Price::all();
+        // Pricing tiers are few (<20); cache for 1 hour
+        $items = Cache::remember('prices', 3600, fn() => Price::all());
         return view('pages.prices', compact('items'));
     }
 

--- a/app/Http/Controllers/ServicesController.php
+++ b/app/Http/Controllers/ServicesController.php
@@ -22,7 +22,8 @@ class ServicesController extends Controller
      */
     public function adminIndex()
     {
-        $services = Service::all();
+        // Services may grow large; paginate 20 per page
+        $services = Service::paginate(20);
         return view('dashboard.services.index', compact('services'));
     }
 

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -5,12 +5,14 @@ namespace App\Http\Controllers;
 use App\Models\TeamMember;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class TeamController extends Controller
 {
     public function index()
     {
-        $members = TeamMember::all();
+        // Team size is small (<50); cache for one hour
+        $members = Cache::remember('team_members', 3600, fn() => TeamMember::all());
         return view('team.index', compact('members'));
     }
 

--- a/resources/views/dashboard/services/index.blade.php
+++ b/resources/views/dashboard/services/index.blade.php
@@ -34,10 +34,11 @@
             @endif
 
             @if($services->count())
+                {{-- Services are paginated in the controller (20 per page) --}}
                 <div class="bg-white rounded-2xl border border-gray-200 shadow-sm">
                     <div class="p-6 border-b border-gray-100 flex items-center justify-between">
                         <h3 class="text-lg font-semibold text-gray-900">Manage Services</h3>
-                        <span class="text-sm text-gray-500">{{ $services->count() }} total</span>
+                        <span class="text-sm text-gray-500">{{ $services->total() }} total</span>
                     </div>
                     <div class="divide-y divide-gray-100" id="servicesList">
                         @foreach($services as $service)
@@ -77,6 +78,9 @@
                             </div>
                         </div>
                         @endforeach
+                    </div>
+                    <div class="p-6">
+                        {{ $services->links() }}
                     </div>
                 </div>
             @else

--- a/resources/views/pages/careers.blade.php
+++ b/resources/views/pages/careers.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'Careers | ' . config('app.name'))
 
 @section('content')
+    {{-- Career listings cached for 30 minutes in controller --}}
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Careers</h1>

--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -1,4 +1,5 @@
 <x-pages-layout title="Contact Us | {{ config('app.name') }}">
+    {{-- Contact methods cached for 1 hour in controller --}}
     <x-slot name="metaDescription">
         Get in touch with Sanaa Co. for questions, support, or business inquiries. We're here to help you succeed with our innovative digital solutions.
     </x-slot>

--- a/resources/views/pages/developer-platforms.blade.php
+++ b/resources/views/pages/developer-platforms.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'Developer Platforms | ' . config('app.name'))
 
 @section('content')
+    {{-- Developer platforms cached for 1 hour in controller --}}
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Developer Platforms</h1>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1136,6 +1136,7 @@
     </section>
 
     <!-- Premium Team Section -->
+    {{-- Team members cached for 1 hour in controller --}}
     <section id="team" class="team-premium">
         <div class="section-header">
             <h2 class="section-title reveal-element">Meet the Team</h2>

--- a/resources/views/pages/partners.blade.php
+++ b/resources/views/pages/partners.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'Partners | ' . config('app.name'))
 
 @section('content')
+    {{-- Partner list cached for 1 hour in controller --}}
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Partners</h1>

--- a/resources/views/pages/prices.blade.php
+++ b/resources/views/pages/prices.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'Prices | ' . config('app.name'))
 
 @section('content')
+    {{-- Pricing data cached for 1 hour in controller --}}
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Pricing</h1>

--- a/resources/views/pages/rent-hardware.blade.php
+++ b/resources/views/pages/rent-hardware.blade.php
@@ -3,6 +3,7 @@
 @section('title', 'Hardware Rentals | ' . config('app.name'))
 
 @section('content')
+    {{-- Hardware rental options cached for 1 hour in controller --}}
     <section class="py-12 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <h1 class="text-2xl font-bold">Rent Hardware</h1>

--- a/resources/views/team/index.blade.php
+++ b/resources/views/team/index.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.landing')
 
 @section('content')
+{{-- Team list cached for 1 hour in controller --}}
 <div class="container mx-auto py-12 px-4">
     <h1 class="text-3xl font-bold mb-8 text-center">Our Team</h1>
     <div class="grid md:grid-cols-3 gap-8">


### PR DESCRIPTION
## Summary
- Cache small partner, contact, career, team, pricing, hardware rental and developer platform listings with sensible TTLs
- Paginate admin service list and display links
- Document expected record volumes for caching and pagination decisions

## Testing
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d6211430832499cd0a7926e3e5c9